### PR TITLE
Simplified Apidoc page

### DIFF
--- a/apidoc.html
+++ b/apidoc.html
@@ -1,0 +1,1066 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title></title>
+    <link rel="stylesheet" type="text/css" href="css/bootstrap.min.css" />
+    <link rel="stylesheet" type="text/css" href="css/bootstrap-responsive.min.css" />
+    <link rel="stylesheet" type="text/css" href="css/main.css" />
+</head>
+<body data-spy="scroll" data-target=".navbar">
+    <div class="container">
+        <head class="main-header" >
+            <a href="/">
+                <img class="main-logo" src="img/logo.png" />
+            </a>
+            <nav class="main-nav navbar">
+                <div class="navbar-inner">
+                    <ul class="nav nav-main mainnav">
+                        <li><a href="#release_history">Release History</a></li>
+                        <li><a href="#downloads">Downloads</a></li>
+                        <li><a href="#other_resources">Other Resources</a></li>
+                    </ul>
+                </div>
+            </nav>
+        </head>
+        <div class="main">
+            <article class="body span8">
+                <section id="release_history">
+                    <h3>Release history</h3>
+                    <p><a href="/ezpublish_version_history/index.php">This graph</a> details the evolution of eZ Publish over time.</p>
+                </section>
+                <section id="downloads">
+                    <h3>API documentation and Source</h3>
+                    <label>Download Format<br />
+                        <select class="download-format-select">
+                            <option value="format-read">Read Online</option>
+                            <option value="format-gz">Gzip</option>
+                            <option value="format-bz2">Bzip 2</option>
+                            <option value="format-zip">Zip</option>
+                        </select>
+                    </label>
+                    <label>
+                        <input type="checkbox" class="toggle-all-formats" value="1" />
+                        Show All Download Formats
+                    </label>
+                    <ul class="nav nav-tabs version-nav">
+                        <li class="active"><a href="#Development" data-toggle="tab">Development</a></li>
+                        <li class="dropdown">
+                            <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+                                Enterprise Edition <b class="caret"></b>
+                            </a>
+                            <ul class="dropdown-menu">
+                                <li><a href="#v50" data-toggle="tab">5.0</a></li>
+                                <li><a href="#v47" data-toggle="tab">4.7</a></li>
+                                <li><a href="#v46" data-toggle="tab">4.6</a></li>
+                                <li><a href="#v45" data-toggle="tab">4.5</a></li>
+                                <li><a href="#v44" data-toggle="tab">4.4</a></li>
+                            </ul>
+                        </li>
+                        <li class="dropdown">
+                            <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+                                Community Edition <b class="caret"></b>
+                            </a>
+                            <ul class="dropdown-menu">
+                                <li><a href="#v20134" data-toggle="tab">2013.4</a></li>
+                                <li><a href="#v20131" data-toggle="tab">2013.1</a></li>
+                                <li><a href="#v201212" data-toggle="tab">2012.12</a></li>
+                            </ul>
+                        </li>
+                        <li class="dropdown">
+                            <a href="#Older" class="dropdown-toggle" data-toggle="dropdown">
+                                Older Releases <b class="caret"></b>
+                            </a>
+                            <ul class="dropdown-menu">
+                                <li><a href="#v43" data-toggle="tab">4.3</a></li>
+                                <li><a href="#v42" data-toggle="tab">4.2</a></li>
+                                <li><a href="#v414" data-toggle="tab">4.1.4</a></li>
+                                <li><a href="#v407" data-toggle="tab">4.0.7</a></li>
+                                <li><a href="#v3101" data-toggle="tab">3.10.1</a></li>
+                                <li><a href="#v395" data-toggle="tab">3.9.5</a></li>
+                                <li><a href="#v3810" data-toggle="tab">3.8.10</a></li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <div class="tab-content">
+                        <div id="Development" class="tab-pane active">
+                            <h3>Development</h3>
+                            <p class="muted">Automatically updated daily from github master branch.</p>
+
+                            <h4>API Docs</h4>
+                            <table class="table">
+                                <thead>
+                                    <tr>
+                                        <th class="stack"></th>
+                                        <th class="doxygen">Doxygen</th>
+                                        <th class="docblox">DocBlox</th>
+                                        <th class="sami">Sami</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr>
+                                        <th>Legacy kernel</th>
+                                        <td>
+                                            <a class="download-link format-read" href="http://pubsvn.ez.no/doxygen/trunk/html/index.html">Read Online</a>
+                                            <a class="download-link format-gz format-bz2" href="http://pubsvn.ez.no/trunk/ezpublish-community_project-trunk-apidocs-doxygen-4X.tar.gz">Download (gz)</a>
+                                            <a class="download-link format-zip" href="http://pubsvn.ez.no/trunk/ezpublish-community_project-trunk-apidocs-doxygen-4X.zip">Download (zip)</a>
+                                            <span class="muted download-link format-bz2">Bz2 not available</span>
+
+                                        </td>
+                                        <td>
+                                            <span class="muted download-link format-all">Docblox Not Available</span>
+                                        </td>
+                                        <td>
+                                            <a class="download-link format-read" href="http://pubsvn.ez.no/sami/trunk/LS/html/index.html">Read Online</a>
+                                            <a class="download-link format-gz format-bz2" href="http://pubsvn.ez.no/trunk/ezpublish-community_project-trunk-apidocs-sami-4X.tar.gz">Download (gz)</a>
+                                            <a class="download-link format-zip" href="http://pubsvn.ez.no/trunk/ezpublish-community_project-trunk-apidocs-sami-4X.zip">Download (zip)</a>
+                                            <span class="muted download-link format-bz2">Bz2 not available</span>
+
+                                        </td>                                        
+                                    </tr>
+                                    <tr>
+                                        <th>5.x kernel</th>
+                                        <td>
+                                            <a class="download-link format-read" href="http://pubsvn.ez.no/doxygen/trunk/NS/html/index.html">Read Online</a>
+                                            <a class="download-link format-gz format-bz2" href="http://pubsvn.ez.no/trunk/ezpublish-community_project-trunk-apidocs-doxygen-NS.tar.gz">Download (gz)</a>
+                                            <a class="download-link format-zip" href="http://pubsvn.ez.no/trunk/ezpublish-community_project-trunk-apidocs-doxygen-NS.zip">Download (zip)</a>
+                                            <span class="muted download-link format-bz2">Bz2 not available</span>
+                                        </td>
+                                        <td>
+                                            <span class="muted download-link format-all">Docblox Not Available</span>
+                                        </td>
+                                        <td>
+                                            <a class="download-link format-read" href="http://pubsvn.ez.no/sami/trunk/NS/html/index.html">Read Online</a>
+                                            <a class="download-link format-gz format-bz2" href="http://pubsvn.ez.no/trunk/ezpublish-community_project-trunk-apidocs-sami-NS.tar.gz">Download (gz)</a>
+                                            <a class="download-link format-zip" href="http://pubsvn.ez.no/trunk/ezpublish-community_project-trunk-apidocs-sami-NS.zip">Download (zip)</a>
+                                            <span class="muted download-link format-bz2">Bz2 not available</span>
+
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
+
+                            <h4>Source</h4>
+                            <table class="table">
+                                <tbody>
+                                    <tr>
+                                        <th class="stack">Legacy kernel</th>
+                                        <td class="github">
+                                            <a href="https://github.com/ezsystems/ezpublish-legacy" class="download-link format-all">Available via Github</a>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <th class="stack">5.x kernel</th>
+                                        <td class="github">
+                                            <a href="https://github.com/ezsystems/ezpublish-kernel" class="download-link format-all">Available via Github</a>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <th class="stack">Full 5.x stack</th>
+                                        <td class="github">
+                                            <a href="https://github.com/ezsystems/ezpublish-community" class="download-link format-all">Available via Github</a>
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
+
+                        </div>
+                        <div id="v50" class="tab-pane">
+                            <h3>5.0 Enterprise Edition</h3>
+
+                            <h4>API Docs</h4>
+                            <table class="table">
+                                <thead>
+                                <tr>
+                                    <th class="stack"></th>
+                                    <th class="doxygen">Doxygen</th>
+                                    <th class="dockblox">DocBlox</th>
+                                    <th class="sami">Sami</th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                <tr>
+                                    <th>Legacy kernel</th>
+                                    <td>
+                                        <a class="download-link format-read" href="http://pubsvn.ez.no/doxygen/5.0.0/LS/index.html">Read Online</a>
+                                        <a class="download-link format-gz format-bz2" href="http://pubsvn.ez.no/doxygen/5.0.0/ezpublish-5.0-apidocs-doxygen-LS.tar.gz">Download (gz)</a>
+                                        <a class="download-link format-zip" href="http://pubsvn.ez.no/doxygen/5.0.0/ezpublish-5.0-apidocs-doxygen-LS.zip">Download (zip)</a>
+                                        <span class="muted download-link format-bz2">Bz2 not available</span>
+
+                                    </td>
+                                    <td>
+                                        <a class="download-link format-read" href="http://pubsvn.ez.no/docblox/5.0.0/LS/index.html">Read Online</a>
+                                        <a class="download-link format-gz format-bz2" href="http://pubsvn.ez.no/docblox/5.0.0/ezpublish-5.0-apidocs-docblox-LS.tar.gz">Download (gz)</a>
+                                        <a class="download-link format-zip" href="http://pubsvn.ez.no/docblox/5.0.0/ezpublish-5.0-apidocs-docblox-LS.zip">Download (zip)</a>
+                                        <span class="muted download-link format-bz2">Bz2 not available</span>
+                                    </td>
+                                    <td>
+                                        <a class="download-link format-read" href="http://pubsvn.ez.no/sami/5.0.0/LS/index.html">Read Online</a>
+                                        <a class="download-link format-gz format-bz2" href="http://pubsvn.ez.no/sami/5.0.0/ezpublish-5.0-apidocs-sami-LS.tar.gz">Download (gz)</a>
+                                        <a class="download-link format-zip" href="http://pubsvn.ez.no/sami/5.0.0/ezpublish-5.0-apidocs-sami-LS.zip">Download (zip)</a>
+                                        <span class="muted download-link format-bz2">Bz2 not available</span>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <th>5.x kernel</th>
+                                    <td>
+                                        <a class="download-link format-read" href="http://pubsvn.ez.no/doxygen/5.0.0/NS/index.html">Read Online</a>
+                                        <a class="download-link format-gz format-bz2" href="http://pubsvn.ez.no/doxygen/5.0.0/ezpublish-5.0-apidocs-doxygen-NS.tar.gz">Download (gz)</a>
+                                        <a class="download-link format-zip" href="http://pubsvn.ez.no/doxygen/5.0.0/ezpublish-5.0-apidocs-doxygen-NS.zip">Download (zip)</a>
+                                        <span class="muted download-link format-bz2">Bz2 not available</span>
+                                    </td>
+                                    <td>
+                                        <p class="muted">Docblox not available</p>
+                                    </td>
+                                    <td>
+                                        <a class="download-link format-read" href="http://pubsvn.ez.no/sami/5.0.0/NS/index.html">Read Online</a>
+                                        <a class="download-link format-gz format-bz2" href="http://pubsvn.ez.no/sami/5.0.0/ezpublish-5.0-apidocs-sami-NS.tar.gz">Download (gz)</a>
+                                        <a class="download-link format-zip" href="http://pubsvn.ez.no/sami/5.0.0/ezpublish-5.0-apidocs-sami-NS.zip">Download (zip)</a>
+                                        <span class="muted download-link format-bz2">Bz2 not available</span>
+                                    </td>
+                                </tr>
+                                </tbody>
+                            </table>
+
+                            <h4>Source</h4>
+                            <p>Source is available via the <a href="http://support.ez.no">Enterprise Portal</a></p>                            
+                        </div>
+                        <div id="v47" class="tab-pane">
+                            <h3>4.7 Enterprise Edition</h3>
+
+                            <h4>API Docs</h4>
+                            <table class="table">
+                                <thead>
+                                <tr>
+                                    <th class="stack"></th>
+                                    <th class="doxygen">Doxygen</th>
+                                    <th class="dockblox">DocBlox</th>
+                                    <th class="sami">Sami</th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                <tr>
+                                    <th>Legacy kernel</th>
+                                    <td>
+                                        <a class="download-link format-read" href="http://pubsvn.ez.no/doxygen/4.7.0/html/index.html">Read Online</a>
+                                        <a class="download-link format-gz format-bz2" href="http://pubsvn.ez.no/doxygen/4.7.0/ezpublish-4.7-apidocs-doxygen.tar.gz">Download (gz)</a>
+                                        <a class="download-link format-zip" href="http://pubsvn.ez.no/doxygen/4.7.0/ezpublish-4.7-apidocs-doxygen.zip">Download (zip)</a>
+                                        <span class="muted download-link format-bz2">Bz2 not available</span>
+
+                                    </td>
+                                    <td>
+                                        <a class="download-link format-read" href="http://pubsvn.ez.no/docblox/4.7.0/html/index.html">Read Online</a>
+                                        <a class="download-link format-gz format-bz2" href="http://pubsvn.ez.no/docblox/4.7.0/ezpublish-4.7-apidocs-docblox.tar.gz">Download (gz)</a>
+                                        <a class="download-link format-zip" href="http://pubsvn.ez.no/docblox/4.7.0/ezpublish-4.7-apidocs-docblox.zip">Download (zip)</a>
+                                        <span class="muted download-link format-bz2">Bz2 not available</span>
+
+                                    </td>
+                                    <td>
+                                        <a class="download-link format-read" href="http://pubsvn.ez.no/sami/4.7.0/html/index.html">Read Online</a>
+                                        <a class="download-link format-gz format-bz2" href="http://pubsvn.ez.no/sami/4.7.0/ezpublish-4.7-apidocs-sami.tar.gz">Download (gz)</a>
+                                        <a class="download-link format-zip" href="http://pubsvn.ez.no/sami/4.7.0/ezpublish-4.7-apidocs-sami.zip">Download (zip)</a>
+                                        <span class="muted download-link format-bz2">Bz2 not available</span>
+
+                                    </td>
+                                </tr>
+                                </tbody>
+                            </table>
+
+                            <h4>Source</h4>
+                            <p>Source is available via the <a href="http://support.ez.no">Enterprise Portal</a></p>
+
+                        </div>
+                        <div id="v46" class="tab-pane">
+                            <h3>4.6 Enterprise Edition</h3>
+
+                            <h4>API Docs</h4>
+                            <table class="table">
+                                <thead>
+                                <tr>
+                                    <th class="stack"></th>
+                                    <th class="doxygen">Doxygen</th>
+                                    <th class="dockblox">DocBlox</th>
+                                    <th class="sami">Sami</th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                <tr>
+                                    <th>Legacy kernel</th>
+                                    <td>
+                                        <a class="download-link format-read format-zip" href="http://pubsvn.ez.no/doxygen/4.6.0/html/index.html">Read Online</a>
+                                        <a class="download-link format-gz format-zip" href="http://pubsvn.ez.no/doxygen/4.6.0/ezpublish-4.6.0-apidocs.tar.gz">Download (gz)</a>
+                                        <a class="download-link format-bz2" href="http://pubsvn.ez.no/doxygen/4.6.0/ezpublish-4.6.0-apidocs.tar.bz2">Download (bz2)</a>
+                                        <span class="muted download-link format-zip">Zip not available</span>
+                                    </td>
+                                    <td>
+                                        <a class="download-link format-read format-zip" href="http://pubsvn.ez.no/docblox/4.6.0/html/index.html">Read Online</a>
+                                        <a class="download-link format-gz format-zip" href="http://pubsvn.ez.no/docblox/4.6.0/ezpublish-4.6.0-apidocs3.tar.gz">Download (gz)</a>
+                                        <a class="download-link format-bz2" href="http://pubsvn.ez.no/docblox/4.6.0/ezpublish-4.6.0-apidocs3.tar.bz2">Download (bz2)</a>
+                                        <span class="muted download-link format-zip">Zip not available</span>
+                                    </td>
+                                    <td>
+                                        <p class="muted">Sami not available</p>
+                                    </td>
+                                </tr>
+                                </tbody>
+                            </table>
+
+                            <h4>Source</h4>
+                            <p>Source is available via the <a href="http://support.ez.no">Enterprise Portal</a></p>
+                        </div>
+                        <div id="v45" class="tab-pane">
+                            <h3>4.5 Enterprise Edition</h3>
+
+                            <h4>API Docs</h4>
+                            <table class="table">
+                                <thead>
+                                <tr>
+                                    <th class="stack"></th>
+                                    <th class="doxygen">Doxygen</th>
+                                    <th class="dockblox">DocBlox</th>
+                                    <th class="sami">Sami</th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                <tr>
+                                    <th>Legacy kernel</th>
+                                    <td>
+                                        <a class="download-link format-read format-zip" href="http://pubsvn.ez.no/doxygen/4.5.0/html/index.html">Read Online</a>
+                                        <a class="download-link format-gz format-zip" href="http://pubsvn.ez.no/doxygen/4.5.0/ezpublish-4.5.0-apidocs.tar.gz">Download (gz)</a>
+                                        <a class="download-link format-bz2" href="http://pubsvn.ez.no/doxygen/4.5.0/ezpublish-4.5.0-apidocs.tar.bz2">Download (bz2)</a>
+                                        <span class="muted download-link format-zip">Zip not available</span>
+                                    </td>
+                                    <td>
+                                        <a class="download-link format-read format-zip" href="http://pubsvn.ez.no/docblox/4.5.0/html/index.html">Read Online</a>
+                                        <a class="download-link format-gz format-zip" href="http://pubsvn.ez.no/docblox/4.5.0/ezpublish-4.5.0-apidocs3.tar.gz">Download (gz)</a>
+                                        <a class="download-link format-bz2" href="http://pubsvn.ez.no/docblox/4.5.0/ezpublish-4.5.0-apidocs3.tar.bz2">Download (bz2)</a>
+                                        <span class="muted download-link format-zip">Zip not available</span>
+                                    </td>
+                                    <td>
+                                        <p class="muted">Sami not available</p>
+                                    </td>
+                                </tr>
+                                </tbody>
+                            </table>
+                            <h4>Source</h4>
+                            <p>Source is available via the <a href="http://support.ez.no">Enterprise Portal</a></p>                            
+                        </div>
+                        <div id="v44" class="tab-pane">
+                            <h3>4.4 Enterprise Edition</h3>
+
+                            <h4>API Docs</h4>
+                            <table class="table">
+                                <thead>
+                                <tr>
+                                    <th class="stack"></th>
+                                    <th class="doxygen">Doxygen</th>
+                                    <th class="dockblox">DocBlox</th>
+                                    <th class="sami">Sami</th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                <tr>
+                                    <th>Legacy kernel</th>
+                                    <td>
+                                        <a class="download-link format-read format-zip" href="http://pubsvn.ez.no/doxygen/4.4.0/html/index.html">Read Online</a>
+                                        <a class="download-link format-gz format-zip" href="http://pubsvn.ez.no/doxygen/4.4.0/ezpublish-4.4.0-apidocs.tar.gz">Download (gz)</a>
+                                        <a class="download-link format-bz2" href="http://pubsvn.ez.no/doxygen/4.4.0/ezpublish-4.4.0-apidocs.tar.bz2">Download (bz2)</a>
+                                        <span class="muted download-link format-zip">Zip not available</span>
+                                    </td>
+                                    <td>
+                                        <a class="download-link format-read format-zip" href="http://pubsvn.ez.no/docblox/4.4.0/html/index.html">Read Online</a>
+                                        <a class="download-link format-gz format-zip" href="http://pubsvn.ez.no/docblox/4.4.0/ezpublish-4.4.0-apidocs3.tar.gz">Download (gz)</a>
+                                        <a class="download-link format-bz2" href="http://pubsvn.ez.no/docblox/4.4.0/ezpublish-4.4.0-apidocs3.tar.bz2">Download (bz2)</a>
+                                        <span class="muted download-link format-zip">Zip not available</span>
+                                    </td>
+                                    <td>
+                                        <p class="muted">Sami not available</p>
+                                    </td>
+                                </tr>
+                                </tbody>
+                            </table>
+
+                            <h4>Source</h4>
+                            <p>Source is available via the <a href="http://support.ez.no">Enterprise Portal</a></p>                            
+                        </div>
+                        <div id="v20134" class="tab-pane">
+                            <h3>Community Release 2013.4</h3>
+
+                            <h4>API Docs</h4>
+                            <table class="table">
+                                <thead>
+                                    <tr>
+                                        <th class="stack"></th>
+                                        <th class="doxygen">Doxygen</th>
+                                        <th class="docblox">DocBlox</th>
+                                        <th class="sami">Sami</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr>
+                                        <th>Legacy kernel</th>
+                                        <td>
+                                            <a class="download-link format-read" href="http://pubsvn.ez.no/doxygen/2013.4/LS/index.html">Read Online</a>
+                                            <a class="download-link format-gz format-bz2" href="http://pubsvn.ez.no/doxygen/2013.4/ezpublish-community_project-2013.4-apidocs-doxygen-LS.tar.gz">Download (gz)</a>
+                                            <a class="download-link format-zip" href="/doxygen/2013.4/ezpublish-community_project-2013.4-apidocs-doxygen-LS.zip">Download (zip)</a>
+                                            <span class="muted download-link format-bz2">Bz2 not available</span>
+
+                                        </td>
+                                        <td>
+                                            <span class="muted download-link format-all">Docblox Not Available</span>
+                                        </td>
+                                        <td>
+                                            <a class="download-link format-read" href="http://pubsvn.ez.no/sami/2013.4/LS/index.html">Read Online</a>
+                                            <a class="download-link format-gz format-bz2" href="http://pubsvn.ez.no/sami/2013.4/ezpublish-community_project-2013.4-apidocs-sami-LS.tar.gz">Download (gz)</a>
+                                            <a class="download-link format-zip" href="http://pubsvn.ez.no/sami/2013.4/ezpublish-community_project-2013.4-apidocs-sami-LS.zip">Download (zip)</a>
+                                            <span class="muted download-link format-bz2">Bz2 not available</span>
+
+                                        </td>                                        
+                                    </tr>
+                                    <tr>
+                                        <th>5.x kernel</th>
+                                        <td>
+                                            <a class="download-link format-read" href="http://pubsvn.ez.no/doxygen/2013.4/NS/index.html">Read Online</a>
+                                            <a class="download-link format-gz format-bz2" href="http://pubsvn.ez.no/doxygen/2013.4/ezpublish-community_project-2013.4-apidocs-doxygen-NS.tar.gz">Download (gz)</a>
+                                            <a class="download-link format-zip" href="http://pubsvn.ez.no/doxygen/2013.4/ezpublish-community_project-2013.4-apidocs-doxygen-NS.zip">Download (zip)</a>
+                                            <span class="muted download-link format-bz2">Bz2 not available</span>
+                                        </td>
+                                        <td>
+                                            <span class="muted download-link format-all">Docblox Not Available</span>
+                                        </td>
+                                        <td>
+                                            <a class="download-link format-read" href="http://pubsvn.ez.no/sami/2013.4/NS/index.html">Read Online</a>
+                                            <a class="download-link format-gz format-bz2" href="http://pubsvn.ez.no/sami/2013.4/ezpublish-community_project-2013.4-apidocs-sami-NS.tar.gz">Download (gz)</a>
+                                            <a class="download-link format-zip" href="http://pubsvn.ez.no/sami/2013.4/ezpublish-community_project-2013.4-apidocs-sami-NS.zip">Download (zip)</a>
+                                            <span class="muted download-link format-bz2">Bz2 not available</span>
+
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
+
+                            <h4>Source</h4>
+                            <table class="table">
+                                <tbody>
+                                    <tr>
+                                        <th class="stack">Legacy kernel</th>
+                                        <td class="github">
+                                            <a href="https://github.com/ezsystems/ezpublish-legacy/tree/2013.4" class="download-link format-all">Available via Github</a>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <th class="stack">5.x kernel</th>
+                                        <td class="github">
+                                            <a href="https://github.com/ezsystems/ezpublish-kernel/tree/2013.4" class="download-link format-all">Available via Github</a>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <th class="stack">Full 5.x stack</th>
+                                        <td class="github">
+                                            <a href="https://github.com/ezsystems/ezpublish-community/tree/2013.4" class="download-link format-all">Available via Github</a>
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                        <div id="v20131" class="tab-pane">
+                            <h3>Community Release 2013.1</h3>
+
+                            <h4>API Docs</h4>
+                            <table class="table">
+                                <thead>
+                                    <tr>
+                                        <th class="stack"></th>
+                                        <th class="doxygen">Doxygen</th>
+                                        <th class="docblox">DocBlox</th>
+                                        <th class="sami">Sami</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr>
+                                        <th>Legacy kernel</th>
+                                        <td>
+                                            <a class="download-link format-read" href="http://pubsvn.ez.no/doxygen/2013.1/LS/index.html">Read Online</a>
+                                            <a class="download-link format-gz format-bz2" href="http://pubsvn.ez.no/doxygen/2013.1/ezpublish-community_project-2013.1-apidocs-doxygen-LS.tar.gz">Download (gz)</a>
+                                            <a class="download-link format-zip" href="/doxygen/2013.1/ezpublish-community_project-2013.1-apidocs-doxygen-LS.zip">Download (zip)</a>
+                                            <span class="muted download-link format-bz2">Bz2 not available</span>
+
+                                        </td>
+                                        <td>
+                                            <span class="muted download-link format-all">Docblox Not Available</span>
+                                        </td>
+                                        <td>
+                                            <a class="download-link format-read" href="http://pubsvn.ez.no/sami/2013.1/LS/index.html">Read Online</a>
+                                            <a class="download-link format-gz format-bz2" href="http://pubsvn.ez.no/sami/2013.1/ezpublish-community_project-2013.1-apidocs-sami-LS.tar.gz">Download (gz)</a>
+                                            <a class="download-link format-zip" href="http://pubsvn.ez.no/sami/2013.1/ezpublish-community_project-2013.1-apidocs-sami-LS.zip">Download (zip)</a>
+                                            <span class="muted download-link format-bz2">Bz2 not available</span>
+
+                                        </td>                                        
+                                    </tr>
+                                    <tr>
+                                        <th>5.x kernel</th>
+                                        <td>
+                                            <a class="download-link format-read" href="http://pubsvn.ez.no/doxygen/2013.1/NS/index.html">Read Online</a>
+                                            <a class="download-link format-gz format-bz2" href="http://pubsvn.ez.no/doxygen/2013.1/ezpublish-community_project-2013.1-apidocs-doxygen-NS.tar.gz">Download (gz)</a>
+                                            <a class="download-link format-zip" href="http://pubsvn.ez.no/doxygen/2013.1/ezpublish-community_project-2013.1-apidocs-doxygen-NS.zip">Download (zip)</a>
+                                            <span class="muted download-link format-bz2">Bz2 not available</span>
+                                        </td>
+                                        <td>
+                                            <span class="muted download-link format-all">Docblox Not Available</span>
+                                        </td>
+                                        <td>
+                                            <a class="download-link format-read" href="http://pubsvn.ez.no/sami/2013.1/NS/index.html">Read Online</a>
+                                            <a class="download-link format-gz format-bz2" href="http://pubsvn.ez.no/sami/2013.1/ezpublish-community_project-2013.1-apidocs-sami-NS.tar.gz">Download (gz)</a>
+                                            <a class="download-link format-zip" href="http://pubsvn.ez.no/sami/2013.1/ezpublish-community_project-2013.1-apidocs-sami-NS.zip">Download (zip)</a>
+                                            <span class="muted download-link format-bz2">Bz2 not available</span>
+
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                            
+                            <h4>Source</h4>
+                            <table class="table">
+                                <tbody>
+                                    <tr>
+                                        <th class="stack">Legacy kernel</th>
+                                        <td class="github">
+                                            <a href="https://github.com/ezsystems/ezpublish-legacy/tree/2013.1" class="download-link format-all">Available via Github</a>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <th class="stack">Full 5.x stack</th>
+                                        <td class="github">
+                                            <a href="https://github.com/ezsystems/ezpublish-community/tree/2013.1" class="download-link format-all">Available via Github</a>
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                        <div id="v201212" class="tab-pane">
+                            <h3>Community Release 2012.12</h3>
+
+                            <h4>API Docs</h4>
+                            <table class="table">
+                                <thead>
+                                    <tr>
+                                        <th class="stack"></th>
+                                        <th class="doxygen">Doxygen</th>
+                                        <th class="docblox">DocBlox</th>
+                                        <th class="sami">Sami</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    <tr>
+                                        <th>Legacy kernel</th>
+                                        <td>
+                                            <a class="download-link format-read" href="http://pubsvn.ez.no/doxygen/2012.12/LS/index.html">Read Online</a>
+                                            <a class="download-link format-gz format-bz2" href="http://pubsvn.ez.no/doxygen/2012.12/ezpublish-community_project-2012.12-apidocs-doxygen-LS.tar.gz">Download (gz)</a>
+                                            <a class="download-link format-zip" href="/doxygen/2012.12/ezpublish-community_project-2012.12-apidocs-doxygen-LS.zip">Download (zip)</a>
+                                            <span class="muted download-link format-bz2">Bz2 not available</span>
+
+                                        </td>
+                                        <td>
+                                            <span class="muted download-link format-all">Docblox Not Available</span>
+                                        </td>
+                                        <td>
+                                            <a class="download-link format-read" href="http://pubsvn.ez.no/sami/2012.12/LS/index.html">Read Online</a>
+                                            <a class="download-link format-gz format-bz2" href="http://pubsvn.ez.no/sami/2012.12/ezpublish-community_project-2012.12-apidocs-sami-LS.tar.gz">Download (gz)</a>
+                                            <a class="download-link format-zip" href="http://pubsvn.ez.no/sami/2012.12/ezpublish-community_project-2012.12-apidocs-sami-LS.zip">Download (zip)</a>
+                                            <span class="muted download-link format-bz2">Bz2 not available</span>
+
+                                        </td>                                        
+                                    </tr>
+                                    <tr>
+                                        <th>5.x kernel</th>
+                                        <td>
+                                            <a class="download-link format-read" href="http://pubsvn.ez.no/doxygen/2012.12/NS/index.html">Read Online</a>
+                                            <a class="download-link format-gz format-bz2" href="http://pubsvn.ez.no/doxygen/2012.12/ezpublish-community_project-2012.12-apidocs-doxygen-NS.tar.gz">Download (gz)</a>
+                                            <a class="download-link format-zip" href="http://pubsvn.ez.no/doxygen/2012.12/ezpublish-community_project-2012.12-apidocs-doxygen-NS.zip">Download (zip)</a>
+                                            <span class="muted download-link format-bz2">Bz2 not available</span>
+                                        </td>
+                                        <td>
+                                            <span class="muted download-link format-all">Docblox Not Available</span>
+                                        </td>
+                                        <td>
+                                            <a class="download-link format-read" href="http://pubsvn.ez.no/sami/2012.12/NS/index.html">Read Online</a>
+                                            <a class="download-link format-gz format-bz2" href="http://pubsvn.ez.no/sami/2012.12/ezpublish-community_project-2012.12-apidocs-sami-NS.tar.gz">Download (gz)</a>
+                                            <a class="download-link format-zip" href="http://pubsvn.ez.no/sami/2012.12/ezpublish-community_project-2012.12-apidocs-sami-NS.zip">Download (zip)</a>
+                                            <span class="muted download-link format-bz2">Bz2 not available</span>
+
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                            
+                            <h4>Source</h4>
+                            <table class="table">
+                                <tbody>
+                                    <tr>
+                                        <th class="stack">Legacy kernel</th>
+                                        <td class="github">
+                                            <a href="https://github.com/ezsystems/ezpublish-legacy/tree/2012.12" class="download-link format-all">Available via Github</a>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <th class="stack">Full 5.x stack</th>
+                                        <td class="github">
+                                            <a href="https://github.com/ezsystems/ezpublish-community/tree/2012.12" class="download-link format-all">Available via Github</a>
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>                            
+                        </div>
+                        <div id="v43" class="tab-pane">
+                            <h3>Version 4.3</h3>
+
+                            <h4>API Docs</h4>
+                            <table class="table">
+                                <thead>
+                                <tr>
+                                    <th class="stack"></th>
+                                    <th class="doxygen">Doxygen</th>
+                                    <th class="dockblox">DocBlox</th>
+                                    <th class="sami">Sami</th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                <tr>
+                                    <th>Legacy kernel</th>
+                                    <td>
+                                        <a class="download-link format-read format-zip" href="http://pubsvn.ez.no/doxygen/4.3.0/html/index.html">Read Online</a>
+                                        <a class="download-link format-gz format-zip" href="http://pubsvn.ez.no/doxygen/4.3.0/ezpublish-4.3.0-apidocs.tar.gz">Download (gz)</a>
+                                        <a class="download-link format-bz2" href="http://pubsvn.ez.no/doxygen/4.3.0/ezpublish-4.3.0-apidocs.tar.bz2">Download (bz2)</a>
+                                        <span class="muted download-link format-zip">Zip not available</span>
+                                    </td>
+                                    <td>
+                                        <a class="download-link format-read format-zip" href="http://pubsvn.ez.no/docblox/4.3.0/html/index.html">Read Online</a>
+                                        <a class="download-link format-gz format-zip" href="http://pubsvn.ez.no/docblox/4.3.0/ezpublish-4.3.0-apidocs3.tar.gz">Download (gz)</a>
+                                        <a class="download-link format-bz2" href="http://pubsvn.ez.no/docblox/4.3.0/ezpublish-4.3.0-apidocs3.tar.bz2">Download (bz2)</a>
+                                        <span class="muted download-link format-zip">Zip not available</span>
+                                    </td>
+                                    <td>
+                                        <p class="muted">Sami not available</p>
+                                    </td>
+                                </tr>
+                                </tbody>
+                            </table>
+
+                            <h4>Source</h4>
+                            <table class="table">
+                                <tbody>
+                                    <tr>
+                                        <th class="stack">Legacy kernel</th>
+                                        <td class="github">
+                                            <a href="https://github.com/ezsystems/ezpublish-legacy/tree/4.3.0" class="download-link format-read">Available via Github</a>
+                                            <a href="https://github.com/ezsystems/ezpublish-legacy/archive/4.3.0.tar.gz" class="download-link format-read format-gz format-bz2">Download (gz)</a>
+                                            <a href="https://github.com/ezsystems/ezpublish-legacy/archive/4.3.0.zip" class="download-link format-read format-zip">Download (zip)</a>
+                                            <span class="muted download-link format-zip">Zip not available</span>
+
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>                            
+                        </div>
+                        <div id="v42" class="tab-pane">
+                            <h3>Version 4.2</h3>
+
+                            <h4>API Docs</h4>
+                            <table class="table">
+                                <thead>
+                                <tr>
+                                    <th class="stack"></th>
+                                    <th class="doxygen">Doxygen</th>
+                                    <th class="dockblox">DocBlox</th>
+                                    <th class="sami">Sami</th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                <tr>
+                                    <th>Legacy kernel</th>
+                                    <td>
+                                        <a class="download-link format-read format-zip" href="http://pubsvn.ez.no/doxygen/4.2.0/html/index.html">Read Online</a>
+                                        <a class="download-link format-gz format-zip" href="http://pubsvn.ez.no/doxygen/4.2.0/ezpublish-4.2.0-apidocs.tar.gz">Download (gz)</a>
+                                        <a class="download-link format-bz2" href="http://pubsvn.ez.no/doxygen/4.2.0/ezpublish-4.2.0-apidocs.tar.bz2">Download (bz2)</a>
+                                        <span class="muted download-link format-zip">Zip not available</span>
+                                    </td>
+                                    <td>
+                                        <a class="download-link format-read format-zip" href="http://pubsvn.ez.no/docblox/4.2.0/html/index.html">Read Online</a>
+                                        <a class="download-link format-gz format-zip" href="http://pubsvn.ez.no/docblox/4.2.0/ezpublish-4.2.0-apidocs3.tar.gz">Download (gz)</a>
+                                        <a class="download-link format-bz2" href="http://pubsvn.ez.no/docblox/4.2.0/ezpublish-4.2.0-apidocs3.tar.bz2">Download (bz2)</a>
+                                        <span class="muted download-link format-zip">Zip not available</span>
+                                    </td>
+                                    <td>
+                                        <p class="muted">Sami not available</p>
+                                    </td>
+                                </tr>
+                                </tbody>
+                            </table>
+
+                            <h4>Source</h4>
+                            <table class="table">
+                                <tbody>
+                                    <tr>
+                                        <th class="stack">Legacy kernel</th>
+                                        <td class="github">
+                                            <a href="https://github.com/ezsystems/ezpublish-legacy/tree/4.2.0" class="download-link format-read">Available via Github</a>
+                                            <a href="https://github.com/ezsystems/ezpublish-legacy/archive/4.2.0.tar.gz" class="download-link format-read format-gz format-bz2">Download (gz)</a>
+                                            <a href="https://github.com/ezsystems/ezpublish-legacy/archive/4.2.0.zip" class="download-link format-read format-zip">Download (zip)</a>
+                                            <span class="muted download-link format-zip">Zip not available</span>
+
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                        <div id="v414" class="tab-pane">
+                            <h3>Version 4.1.4</h3>
+
+                            <h4>API Docs</h4>
+                            <table class="table">
+                                <thead>
+                                <tr>
+                                    <th class="stack"></th>
+                                    <th class="doxygen">Doxygen</th>
+                                    <th class="dockblox">DocBlox</th>
+                                    <th class="sami">Sami</th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                <tr>
+                                    <th>Legacy kernel</th>
+                                    <td>
+                                        <a class="download-link format-read format-zip" href="http://pubsvn.ez.no/doxygen/4.1.4/html/index.html">Read Online</a>
+                                        <a class="download-link format-gz format-zip" href="http://pubsvn.ez.no/doxygen/4.1.4/ezpublish-4.1.4-apidocs.tar.gz">Download (gz)</a>
+                                        <a class="download-link format-bz2" href="http://pubsvn.ez.no/doxygen/4.1.4/ezpublish-4.1.4-apidocs.tar.bz2">Download (bz2)</a>
+                                        <span class="muted download-link format-zip">Zip not available</span>
+                                    </td>
+                                    <td>
+                                        <a class="download-link format-read format-zip" href="http://pubsvn.ez.no/docblox/4.1.4/html/index.html">Read Online</a>
+                                        <a class="download-link format-gz format-zip" href="http://pubsvn.ez.no/docblox/4.1.4/ezpublish-4.1.4-apidocs3.tar.gz">Download (gz)</a>
+                                        <a class="download-link format-bz2" href="http://pubsvn.ez.no/docblox/4.1.4/ezpublish-4.1.4-apidocs3.tar.bz2">Download (bz2)</a>
+                                        <span class="muted download-link format-zip">Zip not available</span>
+                                    </td>
+                                    <td>
+                                        <p class="muted">Sami not available</p>
+                                    </td>
+                                </tr>
+                                </tbody>
+                            </table>
+
+                            <h4>Source</h4>
+                            <table class="table">
+                                <tbody>
+                                    <tr>
+                                        <th class="stack">Legacy kernel</th>
+                                        <td class="github">
+                                            <a href="https://github.com/ezsystems/ezpublish-legacy/tree/4.1.4" class="download-link format-read">Available via Github</a>
+                                            <a href="https://github.com/ezsystems/ezpublish-legacy/archive/4.1.4.tar.gz" class="download-link format-read format-gz format-bz2">Download (gz)</a>
+                                            <a href="https://github.com/ezsystems/ezpublish-legacy/archive/4.1.4.zip" class="download-link format-read format-zip">Download (zip)</a>
+                                            <span class="muted download-link format-zip">Zip not available</span>
+
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                        <div id="v407" class="tab-pane">
+                            <h3>Version 4.0.7</h3>
+
+                            <h4>API Docs</h4>
+                            <table class="table">
+                                <thead>
+                                <tr>
+                                    <th class="stack"></th>
+                                    <th class="doxygen">Doxygen</th>
+                                    <th class="dockblox">DocBlox</th>
+                                    <th class="sami">Sami</th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                <tr>
+                                    <th>Legacy kernel</th>
+                                    <td>
+                                        <a class="download-link format-read format-zip" href="http://pubsvn.ez.no/doxygen/4.0.7/html/index.html">Read Online</a>
+                                        <a class="download-link format-gz format-zip" href="http://pubsvn.ez.no/doxygen/4.0.7/ezpublish-4.0.7-apidocs.tar.gz">Download (gz)</a>
+                                        <a class="download-link format-bz2" href="http://pubsvn.ez.no/doxygen/4.0.7/ezpublish-4.0.7-apidocs.tar.bz2">Download (bz2)</a>
+                                        <span class="muted download-link format-zip">Zip not available</span>
+                                    </td>
+                                    <td>
+                                        <a class="download-link format-read format-zip" href="http://pubsvn.ez.no/docblox/4.0.7/html/index.html">Read Online</a>
+                                        <a class="download-link format-gz format-zip" href="http://pubsvn.ez.no/docblox/4.0.7/ezpublish-4.0.7-apidocs3.tar.gz">Download (gz)</a>
+                                        <a class="download-link format-bz2" href="http://pubsvn.ez.no/docblox/4.0.7/ezpublish-4.0.7-apidocs3.tar.bz2">Download (bz2)</a>
+                                        <span class="muted download-link format-zip">Zip not available</span>
+                                    </td>
+                                    <td>
+                                        <p class="muted">Sami not available</p>
+                                    </td>
+                                </tr>
+                                </tbody>
+                            </table>
+
+                            <h4>Source</h4>
+                            <table class="table">
+                                <tbody>
+                                    <tr>
+                                        <th class="stack">Legacy kernel</th>
+                                        <td class="github">
+                                            <a href="https://github.com/ezsystems/ezpublish-legacy/tree/4.0.7" class="download-link format-read">Available via Github</a>
+                                            <a href="https://github.com/ezsystems/ezpublish-legacy/archive/4.0.7.tar.gz" class="download-link format-read format-gz format-bz2">Download (gz)</a>
+                                            <a href="https://github.com/ezsystems/ezpublish-legacy/archive/4.0.7.zip" class="download-link format-read format-zip">Download (zip)</a>
+                                            <span class="muted download-link format-zip">Zip not available</span>
+
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                        <div id="v3101" class="tab-pane">
+                            <h3>Version 3.10.1</h3>
+
+                            <h4>API Docs</h4>
+                            <table class="table">
+                                <thead>
+                                <tr>
+                                    <th class="stack"></th>
+                                    <th class="doxygen">Doxygen</th>
+                                    <th class="dockblox">DocBlox</th>
+                                    <th class="sami">Sami</th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                <tr>
+                                    <th>Legacy kernel</th>
+                                    <td>
+                                        <a class="download-link format-read format-zip" href="http://pubsvn.ez.no/doxygen/3.10.1/html/index.html">Read Online</a>
+                                        <a class="download-link format-gz format-zip" href="http://pubsvn.ez.no/doxygen/3.10.1/ezpublish-3.10.1-apidocs.tar.gz">Download (gz)</a>
+                                        <a class="download-link format-bz2" href="http://pubsvn.ez.no/doxygen/3.10.1/ezpublish-3.10.1-apidocs.tar.bz2">Download (bz2)</a>
+                                        <span class="muted download-link format-zip">Zip not available</span>
+                                    </td>
+                                    <td>
+                                        <p class="muted">Docblox not available</p>
+                                    </td>
+                                    <td>
+                                        <p class="muted">Sami not available</p>
+                                    </td>
+                                </tr>
+                                </tbody>
+                            </table>
+
+                            <h4>Source</h4>
+                            <table class="table">
+                                <tbody>
+                                    <tr>
+                                        <th class="stack">Legacy kernel</th>
+                                        <td class="github">
+                                            <a href="https://github.com/ezsystems/ezpublish-legacy/tree/3.10.1" class="download-link format-read">Available via Github</a>
+                                            <a href="https://github.com/ezsystems/ezpublish-legacy/archive/3.10.1.tar.gz" class="download-link format-read format-gz format-bz2">Download (gz)</a>
+                                            <a href="https://github.com/ezsystems/ezpublish-legacy/archive/3.10.1.zip" class="download-link format-read format-zip">Download (zip)</a>
+                                            <span class="muted download-link format-zip">Zip not available</span>
+
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                        <div id="v395" class="tab-pane">
+                            <h3>Version 3.9.5</h3>
+
+                            <h4>API Docs</h4>
+                            <table class="table">
+                                <thead>
+                                <tr>
+                                    <th class="stack"></th>
+                                    <th class="doxygen">Doxygen</th>
+                                    <th class="dockblox">DocBlox</th>
+                                    <th class="sami">Sami</th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                <tr>
+                                    <th>Legacy kernel</th>
+                                    <td>
+                                        <a class="download-link format-read format-zip" href="http://pubsvn.ez.no/doxygen/3.9.5/html/index.html">Read Online</a>
+                                        <a class="download-link format-gz format-zip" href="http://pubsvn.ez.no/doxygen/3.9.5/ezpublish-3.9.5-apidocs.tar.gz">Download (gz)</a>
+                                        <a class="download-link format-bz2" href="http://pubsvn.ez.no/doxygen/3.9.5/ezpublish-3.9.5-apidocs.tar.bz2">Download (bz2)</a>
+                                        <span class="muted download-link format-zip">Zip not available</span>
+                                    </td>
+                                    <td>
+                                        <p class="muted">Docblox not available</p>
+                                    </td>
+                                    <td>
+                                        <p class="muted">Sami not available</p>
+                                    </td>
+                                </tr>
+                                </tbody>
+                            </table>
+
+                            <h4>Source</h4>
+                            <table class="table">
+                                <tbody>
+                                    <tr>
+                                        <th class="stack">Legacy kernel</th>
+                                        <td class="github">
+                                            <a href="https://github.com/ezsystems/ezpublish-legacy/tree/3.9.5" class="download-link format-read">Available via Github</a>
+                                            <a href="https://github.com/ezsystems/ezpublish-legacy/archive/3.9.5.tar.gz" class="download-link format-read format-gz format-bz2">Download (gz)</a>
+                                            <a href="https://github.com/ezsystems/ezpublish-legacy/archive/3.9.5.zip" class="download-link format-read format-zip">Download (zip)</a>
+                                            <span class="muted download-link format-zip">Zip not available</span>
+
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                        <div id="v3810" class="tab-pane">
+                            <h3>Version 3.8.10</h3>
+
+                            <h4>API Docs</h4>
+                            <table class="table">
+                                <thead>
+                                <tr>
+                                    <th class="stack"></th>
+                                    <th class="doxygen">Doxygen</th>
+                                    <th class="dockblox">DocBlox</th>
+                                    <th class="sami">Sami</th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                <tr>
+                                    <th>Legacy kernel</th>
+                                    <td>
+                                        <a class="download-link format-read format-zip" href="http://pubsvn.ez.no/doxygen/3.8.10/html/index.html">Read Online</a>
+                                        <a class="download-link format-gz format-zip" href="http://pubsvn.ez.no/doxygen/3.8.10/ezpublish-3.8.10-apidocs.tar.gz">Download (gz)</a>
+                                        <a class="download-link format-bz2" href="http://pubsvn.ez.no/doxygen/3.8.10/ezpublish-3.8.10-apidocs.tar.bz2">Download (bz2)</a>
+                                        <span class="muted download-link format-zip">Zip not available</span>
+                                    </td>
+                                    <td>
+                                        <p class="muted">Docblox not available</p>
+                                    </td>
+                                    <td>
+                                        <p class="muted">Sami not available</p>
+                                    </td>
+                                </tr>
+                                </tbody>
+                            </table>
+
+                            <h4>Source</h4>
+                            <table class="table">
+                                <tbody>
+                                    <tr>
+                                        <th class="stack">Legacy kernel</th>
+                                        <td class="github">
+                                            <a href="https://github.com/ezsystems/ezpublish-legacy/tree/3.8.10" class="download-link format-read">Available via Github</a>
+                                            <a href="https://github.com/ezsystems/ezpublish-legacy/archive/3.8.10.tar.gz" class="download-link format-read format-gz format-bz2">Download (gz)</a>
+                                            <a href="https://github.com/ezsystems/ezpublish-legacy/archive/3.8.10.zip" class="download-link format-read format-zip">Download (zip)</a>
+                                            <span class="muted download-link format-zip">Zip not available</span>
+
+                                        </td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </section>
+                <section id="other_resources">
+                    <h3>Other Resources</h3>
+                    <div class="tile">
+                        <h4>eZ Community website</h4>
+                        <p><a href="http://share.ez.no">share.ez.no</a> is an online community dedicated to eZ Publish</p>
+                        <a class="btn" href="http://share.ez.no/get-involved">Get involved!</a>
+                    </div>
+                    <div class="tile">
+                        <h4>GitHub</h4>
+                        <p>All eZ Publish development is available on Github for public access.</p>
+                        <a class="btn" href="http://github.com/ezsystems">Access eZ code</a>
+                    </div>
+                    <div class="tile">
+                        <h4>Jira</h4>
+                        <p>Bugs and new features can be reported at jira.ez.no.</p>
+                        <a class="btn" href="http://jira.ez.no">View Issues</a>
+                    </div>
+                    <div class="tile">
+                        <h4>eZ Publish Extensions</h4>
+                        <p><a href="http://projects.ez.no">Projects.ez.no</a> maintains a community directory of extensions. Older extensions are available via <a href="http://svn.ez.no/svn/extensions">SVN</a></p>
+                        <a class="btn" href="http://projects.ez.no">Get Extensions</a>
+                    </div>
+
+                    <div class="tile">                        
+                        <h4>eZpedia community wiki</h4>
+                        <p>eZpedia is a community-edited repository of eZ Publish information</p>
+                        <a class="btn" href="http://share.ez.no/get-involved">Read eZpedia</a>
+                    </div>
+                    <div class="tile">
+                        <h4>Feeds</h4>
+                        <p>Planet eZ Publish aggregates posts from a large number of eZ Publish blogs.</p>
+                        <a class="btn" href="http://www.planetezpublish.org/">Read Posts</a>
+                    </div>
+                    <div class="tile">
+                        <h4>Documentation</h4>
+                        <p>Official eZ Publish documentation for the current release can be found online.</p>
+                        <a class="btn" href="http://doc.ez.no/">Legacy Docs</a><br />
+                        <a class="btn" href="http://confluence.ez.no/">5.x Docs</a>
+                    </div>
+                </section>
+
+            </article>
+            <sidebar class="news span3">
+                <h4>News</h4>
+                <ul>
+
+                    <li><p>2013.4.29 : added docs for eZP 4.7, 5.0, 2012.12, 2013.1 and 2013.4; fixed links to Github</p></li>
+
+                    <li><p>2013.1.14 : upgraded doxygen and piwik; added doc for latest CP versions; added more links to sources on github</p></li>
+
+                    <li><p>2012.07.26 : added documentation for the CP versions; a bit of styling love...</p></li>
+
+                    <li><p>2012.06.13 : updated doxygen and piwik</p></li>
+
+                    <li><p>2012.01.23 : updated doxygen to 1.7.6.1, docblox 1.8.1 and phpdoc 1.4.4; added documentation for versions 4.6 and 4.5; changed documentation for all branches (except trunk) - it is now generated from release versions, not from git branches anymore</p></li>
+
+                    <li><p>2011.08.28 : updated doxygen to 1.5.1; added documentation generated with the docblox tool</p></li>
+
+                    <li><p>2011.03.29 : moved to a new server; disabled access stats, viewvc, websvn, statsvn and SVN access; added phpdoc-generated docs; updated doxygen to 1.7.4; added some directories to those scanned for php classes</p></li>
+
+                    <li><p>2010.10.12 : added the 4.4 stable branch; reactivated doc generation and source tarball creation from github sources for all branches starting from 4.0</p></li>
+
+                    <li><p>2010.04.13 : added the 4.3 stable branch;<br/>updated websvn, viewvc, statsvn and doxygen;<br/>added <a href="/piwik">Piwik stats</a></p></li>
+
+                    <li><p>2009.09.30 : added the 4.2 stable branch</p></li>
+
+                    <li><p>2009.09.22 : updated viewvc to version 1.1.2</p></li>
+
+                    <li><p>2009.05.20 : updated php to version 5 to fix problems with websvn on some php files; enabled http compression</p></li>
+
+                    <li><p>2009.05.18 : access statistics are back for everybody; updated viewvc to version 1.1.0, websvn to version 2.2.1</p></li>
+
+                    <li><p>2009.05.07 : added a websvn view to the "extensions" svn repository and changed its servername from zev.ez.no to svn.ez.no; Added statsvn-generated stats to all eZP branches</p></li>
+
+                    <li><p>2009.05.06 : The api docs generated via Doxygen are now available for download as a zip files</p></li>
+
+                    <li><p>2009.04.17 : The tools installed on the community server have been upgraded to the latest available version (viewvc, doxygen,
+                        statsvn, websvn2). Websvn 1 and ViewCVS have been removed as old and unmaintained. Added link to 4.1 branch and corrected the generation scripts</p></li>
+
+                    <li><p>2008.03.31 : The community repository has been made read-only on the 31st of March 2008 and will rest in peace, in favor of <a href="http://projects.ez.no">eZ Projects</a>.
+                        We recommend everyone to move their extensions to eZ Projects as soon as possible. For more information, please read
+                        <a href="http://blog.coomanskristof.be/2008/02/27/pubsvn-community-subversion-repository-closing-31st-of-march/">Kristof's blog article regarding this topic</a>.
+                    </p></li>
+
+                    <li><p>Some extensions have been made read-only in the community repository, because they are now using the project spaces at
+                        <a href="http://projects.ez.no">eZ projects</a> instead. eZpedia offers
+                        <a href="http://ezpedia.org/wiki/en/ez/pubsvn_commit_access_restrictions">a list of these read-only paths in the community
+                            repository</a>. We recommend everyone to move their extensions to eZ projects. If you do so then send a list with the related
+                        paths in the community repository to <a href="mailto:kristof.coomans@telenet.be">Kristof</a> so he can make them read-only.
+                    </p></li>
+
+                    <!--<h2 id="nextgen_php5">The nextgen_php5 repository is deprecated</h2>-->
+                    <li><p>The nextgen_php5 repository is deprecated. It contains a PHP 5 port of eZ Publish 3.9. It was started by the eZ Publish Community. eZ Systems has adopted the port and based on the initial work done by the community, they were able to release eZ Publish 4 in December 2007. It is recommended that you use the official version from eZ Systems, because no further updates will be done on the community port.</p></li>
+
+                </ul>
+
+            </sidebar>
+        </div>
+    </div>
+    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+    <script type="text/javascript" src="js/bootstrap.min.js"></script>
+    <script type="text/javascript" src="js/main.js"></script>
+</body>
+</html>

--- a/apidoc.html
+++ b/apidoc.html
@@ -989,61 +989,6 @@
                 </section>
 
             </article>
-            <sidebar class="news span3">
-                <h4>News</h4>
-                <ul>
-
-                    <li><p>2013.4.29 : added docs for eZP 4.7, 5.0, 2012.12, 2013.1 and 2013.4; fixed links to Github</p></li>
-
-                    <li><p>2013.1.14 : upgraded doxygen and piwik; added doc for latest CP versions; added more links to sources on github</p></li>
-
-                    <li><p>2012.07.26 : added documentation for the CP versions; a bit of styling love...</p></li>
-
-                    <li><p>2012.06.13 : updated doxygen and piwik</p></li>
-
-                    <li><p>2012.01.23 : updated doxygen to 1.7.6.1, docblox 1.8.1 and phpdoc 1.4.4; added documentation for versions 4.6 and 4.5; changed documentation for all branches (except trunk) - it is now generated from release versions, not from git branches anymore</p></li>
-
-                    <li><p>2011.08.28 : updated doxygen to 1.5.1; added documentation generated with the docblox tool</p></li>
-
-                    <li><p>2011.03.29 : moved to a new server; disabled access stats, viewvc, websvn, statsvn and SVN access; added phpdoc-generated docs; updated doxygen to 1.7.4; added some directories to those scanned for php classes</p></li>
-
-                    <li><p>2010.10.12 : added the 4.4 stable branch; reactivated doc generation and source tarball creation from github sources for all branches starting from 4.0</p></li>
-
-                    <li><p>2010.04.13 : added the 4.3 stable branch;<br/>updated websvn, viewvc, statsvn and doxygen;<br/>added <a href="/piwik">Piwik stats</a></p></li>
-
-                    <li><p>2009.09.30 : added the 4.2 stable branch</p></li>
-
-                    <li><p>2009.09.22 : updated viewvc to version 1.1.2</p></li>
-
-                    <li><p>2009.05.20 : updated php to version 5 to fix problems with websvn on some php files; enabled http compression</p></li>
-
-                    <li><p>2009.05.18 : access statistics are back for everybody; updated viewvc to version 1.1.0, websvn to version 2.2.1</p></li>
-
-                    <li><p>2009.05.07 : added a websvn view to the "extensions" svn repository and changed its servername from zev.ez.no to svn.ez.no; Added statsvn-generated stats to all eZP branches</p></li>
-
-                    <li><p>2009.05.06 : The api docs generated via Doxygen are now available for download as a zip files</p></li>
-
-                    <li><p>2009.04.17 : The tools installed on the community server have been upgraded to the latest available version (viewvc, doxygen,
-                        statsvn, websvn2). Websvn 1 and ViewCVS have been removed as old and unmaintained. Added link to 4.1 branch and corrected the generation scripts</p></li>
-
-                    <li><p>2008.03.31 : The community repository has been made read-only on the 31st of March 2008 and will rest in peace, in favor of <a href="http://projects.ez.no">eZ Projects</a>.
-                        We recommend everyone to move their extensions to eZ Projects as soon as possible. For more information, please read
-                        <a href="http://blog.coomanskristof.be/2008/02/27/pubsvn-community-subversion-repository-closing-31st-of-march/">Kristof's blog article regarding this topic</a>.
-                    </p></li>
-
-                    <li><p>Some extensions have been made read-only in the community repository, because they are now using the project spaces at
-                        <a href="http://projects.ez.no">eZ projects</a> instead. eZpedia offers
-                        <a href="http://ezpedia.org/wiki/en/ez/pubsvn_commit_access_restrictions">a list of these read-only paths in the community
-                            repository</a>. We recommend everyone to move their extensions to eZ projects. If you do so then send a list with the related
-                        paths in the community repository to <a href="mailto:kristof.coomans@telenet.be">Kristof</a> so he can make them read-only.
-                    </p></li>
-
-                    <!--<h2 id="nextgen_php5">The nextgen_php5 repository is deprecated</h2>-->
-                    <li><p>The nextgen_php5 repository is deprecated. It contains a PHP 5 port of eZ Publish 3.9. It was started by the eZ Publish Community. eZ Systems has adopted the port and based on the initial work done by the community, they were able to release eZ Publish 4 in December 2007. It is recommended that you use the official version from eZ Systems, because no further updates will be done on the community port.</p></li>
-
-                </ul>
-
-            </sidebar>
         </div>
     </div>
     <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>

--- a/apidoc.html
+++ b/apidoc.html
@@ -974,14 +974,10 @@
                     </div>
 
                     <div class="tile">                        
-                        <h4>eZpedia community wiki</h4>
-                        <p>eZpedia is a community-edited repository of eZ Publish information</p>
-                        <a class="btn" href="http://share.ez.no/get-involved">Read eZpedia</a>
-                    </div>
-                    <div class="tile">
-                        <h4>Feeds</h4>
-                        <p>Planet eZ Publish aggregates posts from a large number of eZ Publish blogs.</p>
-                        <a class="btn" href="http://www.planetezpublish.org/">Read Posts</a>
+                        <h4>Additional Community Resources</h4>
+                        <p>Some Community maintained resources for additional knowledge sharing.</p>
+                        <a class="btn" href="http://share.ez.no/get-involved">eZpedia Community-wiki</a>
+                        <a class="btn" href="http://www.planetezpublish.org/">Planet ezpublish</a>
                     </div>
                 </section>
 

--- a/apidoc.html
+++ b/apidoc.html
@@ -15,10 +15,6 @@
         </head>
         <div class="main">
             <article class="body span8">
-                <section id="release_history">
-                    <h3>Release history</h3>
-                    <p><a href="/ezpublish_version_history/index.php">This graph</a> details the evolution of eZ Publish over time.</p>
-                </section>
                 <section id="downloads">
                     <h3>API documentation and Source</h3>
                     <label>Download Format<br />

--- a/apidoc.html
+++ b/apidoc.html
@@ -6,21 +6,12 @@
     <link rel="stylesheet" type="text/css" href="css/bootstrap-responsive.min.css" />
     <link rel="stylesheet" type="text/css" href="css/main.css" />
 </head>
-<body data-spy="scroll" data-target=".navbar">
+<body data-spy="scroll">
     <div class="container">
         <head class="main-header" >
             <a href="/">
                 <img class="main-logo" src="img/logo.png" />
             </a>
-            <nav class="main-nav navbar">
-                <div class="navbar-inner">
-                    <ul class="nav nav-main mainnav">
-                        <li><a href="#release_history">Release History</a></li>
-                        <li><a href="#downloads">Downloads</a></li>
-                        <li><a href="#other_resources">Other Resources</a></li>
-                    </ul>
-                </div>
-            </nav>
         </head>
         <div class="main">
             <article class="body span8">

--- a/apidoc.html
+++ b/apidoc.html
@@ -9,7 +9,7 @@
 <body data-spy="scroll">
     <div class="container">
         <div class="main">
-            <article class="body span8">
+            <article class="body span12">
                 <section id="downloads">
                     <h3>API documentation and Source</h3>
                     <label>Download Format<br />

--- a/apidoc.html
+++ b/apidoc.html
@@ -8,11 +8,6 @@
 </head>
 <body data-spy="scroll">
     <div class="container">
-        <head class="main-header" >
-            <a href="/">
-                <img class="main-logo" src="img/logo.png" />
-            </a>
-        </head>
         <div class="main">
             <article class="body span8">
                 <section id="downloads">

--- a/apidoc.html
+++ b/apidoc.html
@@ -945,9 +945,10 @@
                 <section id="other_resources">
                     <h3>Other Resources</h3>
                     <div class="tile">
-                        <h4>eZ Community website</h4>
-                        <p><a href="http://share.ez.no">share.ez.no</a> is an online community dedicated to eZ Publish</p>
-                        <a class="btn" href="http://share.ez.no/get-involved">Get involved!</a>
+                        <h4>Documentation</h4>
+                        <p>Official eZ Publish documentation for the current release can be found online.</p>
+                        <a class="btn" href="http://doc.ez.no/">Legacy Docs</a><br />
+                        <a class="btn" href="http://confluence.ez.no/">5.x Docs</a>
                     </div>
                     <div class="tile">
                         <h4>GitHub</h4>
@@ -959,6 +960,13 @@
                         <p>Bugs and new features can be reported at jira.ez.no.</p>
                         <a class="btn" href="http://jira.ez.no">View Issues</a>
                     </div>
+
+                    <div class="tile">
+                        <h4>eZ Community website</h4>
+                        <p><a href="http://share.ez.no">share.ez.no</a> is an online community dedicated to eZ Publish</p>
+                        <a class="btn" href="http://share.ez.no/get-involved">Get involved!</a>
+                    </div>
+
                     <div class="tile">
                         <h4>eZ Publish Extensions</h4>
                         <p><a href="http://projects.ez.no">Projects.ez.no</a> maintains a community directory of extensions. Older extensions are available via <a href="http://svn.ez.no/svn/extensions">SVN</a></p>
@@ -974,12 +982,6 @@
                         <h4>Feeds</h4>
                         <p>Planet eZ Publish aggregates posts from a large number of eZ Publish blogs.</p>
                         <a class="btn" href="http://www.planetezpublish.org/">Read Posts</a>
-                    </div>
-                    <div class="tile">
-                        <h4>Documentation</h4>
-                        <p>Official eZ Publish documentation for the current release can be found online.</p>
-                        <a class="btn" href="http://doc.ez.no/">Legacy Docs</a><br />
-                        <a class="btn" href="http://confluence.ez.no/">5.x Docs</a>
                     </div>
                 </section>
 

--- a/css/main.css
+++ b/css/main.css
@@ -5,26 +5,6 @@ th.doxygen { width: 29%; }
 th.docblox { width: 28%; }
 th.sami { width: 28%; }
 
-.main-nav.affix { top: 0; width: 1170px; z-index: 20; }
-
-.navbar-inner {
-    background: #ff9e00; /* Old browsers */
-    background: -moz-linear-gradient(top, #ff9e00 0%, #ffc054 51%, #ff9e00 100%); /* FF3.6+ */
-    background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#ff9e00), color-stop(51%,#ffc054), color-stop(100%,#ff9e00)); /* Chrome,Safari4+ */
-    background: -webkit-linear-gradient(top, #ff9e00 0%,#ffc054 51%,#ff9e00 100%); /* Chrome10+,Safari5.1+ */
-    background: -o-linear-gradient(top, #ff9e00 0%,#ffc054 51%,#ff9e00 100%); /* Opera 11.10+ */
-    background: -ms-linear-gradient(top, #ff9e00 0%,#ffc054 51%,#ff9e00 100%); /* IE10+ */
-    background: linear-gradient(to bottom, #ff9e00 0%,#ffc054 51%,#ff9e00 100%); /* W3C */
-    filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#ff9e00', endColorstr='#ff9e00',GradientType=0 ); /* IE6-9 */
-    border-radius: 0;
-    border-color: #ff9a00;
-}
-.navbar .nav>li>a { text-shadow: none; color: black;}
-
-.navbar .nav>.active>a, .navbar .nav>.active>a:hover, .navbar .nav>.active>a:focus {
-    background: #f69000; color: black;
-}
-
 .version-nav { margin-bottom: 5px; }
 .tab-pane h3 { margin-top: 0; }
 

--- a/css/main.css
+++ b/css/main.css
@@ -5,6 +5,26 @@ th.doxygen { width: 29%; }
 th.docblox { width: 28%; }
 th.sami { width: 28%; }
 
+.main-nav.affix { top: 0; width: 1170px; z-index: 20; }
+
+.navbar-inner {
+    background: #ff9e00; /* Old browsers */
+    background: -moz-linear-gradient(top, #ff9e00 0%, #ffc054 51%, #ff9e00 100%); /* FF3.6+ */
+    background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#ff9e00), color-stop(51%,#ffc054), color-stop(100%,#ff9e00)); /* Chrome,Safari4+ */
+    background: -webkit-linear-gradient(top, #ff9e00 0%,#ffc054 51%,#ff9e00 100%); /* Chrome10+,Safari5.1+ */
+    background: -o-linear-gradient(top, #ff9e00 0%,#ffc054 51%,#ff9e00 100%); /* Opera 11.10+ */
+    background: -ms-linear-gradient(top, #ff9e00 0%,#ffc054 51%,#ff9e00 100%); /* IE10+ */
+    background: linear-gradient(to bottom, #ff9e00 0%,#ffc054 51%,#ff9e00 100%); /* W3C */
+    filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#ff9e00', endColorstr='#ff9e00',GradientType=0 ); /* IE6-9 */
+    border-radius: 0;
+    border-color: #ff9a00;
+}
+.navbar .nav>li>a { text-shadow: none; color: black;}
+
+.navbar .nav>.active>a, .navbar .nav>.active>a:hover, .navbar .nav>.active>a:focus {
+    background: #f69000; color: black;
+}
+
 .version-nav { margin-bottom: 5px; }
 .tab-pane h3 { margin-top: 0; }
 


### PR DESCRIPTION
We are currently in the process of also setting up apidoc.ez.no, here is a proposal on how that could look like where main focus is the doc, and parts like the navigation, changelog and so on are removed to have a very clean landing page for [api doc](http://andrerom.github.io/ezpubreleasepage).

Note: Some rebasing could be done here to avoid the temporary removal of main.css css rules.
